### PR TITLE
Only prevent fixup step on macs

### DIFF
--- a/pkgs/android/generic.nix
+++ b/pkgs/android/generic.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (rec {
   };
 
   # Fixup attempts to strip executables and libraries by default, which causes problems on M1 macs.
-  dontFixup = true;
+  dontFixup = targetPlatform.isDarwin;
 
   setSourceRoot = ''
     sourceRoot="$out"


### PR DESCRIPTION
Running fixup seems to bork things on M1, but is necessary to work on linux.